### PR TITLE
Tooltip

### DIFF
--- a/map/chicagoHeatMap.js
+++ b/map/chicagoHeatMap.js
@@ -64,6 +64,15 @@ var heatMapVis = function(){
                         .attr("width", width)
                         .attr("height", height)
 
+                //Creates tool-tip box
+                var tool_tip = d3.tip()
+                    .attr("class", "d3-tip")
+                    .offset([20, 120])
+                    .html( "<p>Region:</p><div id='tipDiv'></div>"
+                    );
+
+                svg.call(tool_tip);
+
 
                 //Bind data and create one path per GeoJSON feature
                 svg.selectAll("path")
@@ -88,7 +97,38 @@ var heatMapVis = function(){
                     return `rgb(${Math.floor(red)}, ${Math.floor(green)}, ${Math.floor(blue)})`;
                     }
                 })
-                .on("click", function(d){newHeatMap.dispatch.call("selected", {}, SATdict[d.properties.ZIP]);});
+
+
+                .on("mouseover", function(d) {
+                    tool_tip.show();
+                    var tipSVG = d3.select("#tipDiv")
+                    .append("svg")
+                    .attr("width", 150)
+                    .attr("height", 100);
+
+                    tipSVG.append("rect")
+                        .attr("fill", "steelblue")
+                        .attr("y", 10) //y position of the bar
+                        .attr("width", 0) //position of how far the bar starts at
+                        .attr("height", 20) //the thickness of the bar
+                        .transition() //facilitates the transition from empty canvas to bar
+                        .duration(1000) //how long it takes for the bar to move
+                        .attr("width", function() {
+                           return SATbarwidth(SATdict[d.properties.ZIP]);
+                        }); //length of the bar
+
+                tipSVG.append("text")
+                    .text(SATdict[d.properties.ZIP])
+                    .attr("x", 5)
+                    .attr("y", 30)
+                    .transition()
+                    .duration(1000)
+                    .attr("x", 6 + SATbarwidth(SATdict[d.properties.ZIP]))
+                })
+                .on('mouseout', tool_tip.hide)
+
+                .on("click", function(d){newHeatMap.dispatch.call("selected", {}, SATdict[d.properties.ZIP]);}
+                   );
                 
 
             });
@@ -101,3 +141,14 @@ var heatMapVis = function(){
     }
     return newHeatMap;
 }
+
+//determines whether the SATScore is a valid number for the bar length
+function SATbarwidth(SATscore) {
+    if (SATscore === undefined || isNaN(SATscore) ) {
+        return 2;
+    }      
+    return SATscore *.1;
+}
+
+// if SAT is undefined, return empty bar with width 0
+// If SAT is null, return empty bar with width 0.

--- a/map/chicagoHeatMap.js
+++ b/map/chicagoHeatMap.js
@@ -10,6 +10,7 @@ var heatMapVis = function(){
                 d3.csv("https://dhruvkore.github.io/DataVisualization_FinalProject/map/Avg-SAT-by-Zip-Chi.csv", function(data){
                     var SATdict = {};
                     var rentDict={};
+                    var zipcode = {};
                     
                     var sats = [];
                     var rents = [];
@@ -19,6 +20,8 @@ var heatMapVis = function(){
                         rents.push(data[d].MedGrossRent)
                         SATdict[data[d].zip] = data[d].avgSAT;
                         rentDict[data[d].zip] = data[d].MedGrossRent;
+                        zipcode[data[d].zip] = data[d].zip;
+
                     }
 
                     var maxSAT = Math.max(...sats);
@@ -68,7 +71,8 @@ var heatMapVis = function(){
                 var tool_tip = d3.tip()
                     .attr("class", "d3-tip")
                     .offset([20, 120])
-                    .html( "<p>Region:</p><div id='tipDiv'></div>"
+                    .html(
+                         "<p id='region'></p><div id='tipDiv'></div>"
                     );
 
                 svg.call(tool_tip);
@@ -101,6 +105,12 @@ var heatMapVis = function(){
 
                 .on("mouseover", function(d) {
                     tool_tip.show();
+
+                    d3.select("p#region")
+                        .append("text")
+                        .text("Neighborhood: " + zipcode[d.properties.ZIP]);
+
+
                     var tipSVG = d3.select("#tipDiv")
                     .append("svg")
                     .attr("width", 150)
@@ -114,16 +124,17 @@ var heatMapVis = function(){
                         .transition() //facilitates the transition from empty canvas to bar
                         .duration(1000) //how long it takes for the bar to move
                         .attr("width", function() {
+                            console.log(rentDict[d.properties.ZIP]);
                            return SATbarwidth(SATdict[d.properties.ZIP]);
                         }); //length of the bar
 
-                tipSVG.append("text")
-                    .text(SATdict[d.properties.ZIP])
-                    .attr("x", 5)
-                    .attr("y", 30)
-                    .transition()
-                    .duration(1000)
-                    .attr("x", 6 + SATbarwidth(SATdict[d.properties.ZIP]))
+                    tipSVG.append("text")
+                        .text(SATdict[d.properties.ZIP])
+                        .attr("x", 5)
+                        .attr("y", 30)
+                        .transition()
+                        .duration(1000)
+                        .attr("x", 6 + SATbarwidth(SATdict[d.properties.ZIP]))
                 })
                 .on('mouseout', tool_tip.hide)
 
@@ -132,8 +143,6 @@ var heatMapVis = function(){
                 
 
             });
-                
-
             });
         },
 
@@ -149,6 +158,13 @@ function SATbarwidth(SATscore) {
     }      
     return SATscore *.1;
 }
+
+// given value, create the text for tooltips
+function tipsText(value) {
+
+}
+
+
 
 // if SAT is undefined, return empty bar with width 0
 // If SAT is null, return empty bar with width 0.

--- a/map/chicagoHeatMap.js
+++ b/map/chicagoHeatMap.js
@@ -67,12 +67,12 @@ var heatMapVis = function(){
                         .attr("width", width)
                         .attr("height", height)
 
-                //Creates tool-tip box
+                //Creates tool-tip 
                 var tool_tip = d3.tip()
                     .attr("class", "d3-tip")
                     .offset([20, 120])
                     .html(
-                         "<p id='region'></p><div id='tipDiv'></div>"
+                         "<p id='region'></p><div id='tipDiv'><p>Averages:</p></div><div id='tipRent'></div>"
                     );
 
                 svg.call(tool_tip);
@@ -116,33 +116,58 @@ var heatMapVis = function(){
                     .attr("width", 150)
                     .attr("height", 100);
 
+                    var tiprent = d3.select("#tipDiv").select("svg");
+                 
+                   
+
+                // For SATS score bar:
                     tipSVG.append("rect")
                         .attr("fill", "steelblue")
-                        .attr("y", 10) //y position of the bar
+                        .attr("y", 0) //y position of the bar
                         .attr("width", 0) //position of how far the bar starts at
                         .attr("height", 20) //the thickness of the bar
                         .transition() //facilitates the transition from empty canvas to bar
-                        .duration(1000) //how long it takes for the bar to move
+                        .duration(900) //how long it takes for the bar to move
                         .attr("width", function() {
-                            console.log(rentDict[d.properties.ZIP]);
-                           return SATbarwidth(SATdict[d.properties.ZIP]);
-                        }); //length of the bar
+                          
+                           return barwidth(SATdict[d.properties.ZIP]);
+                        }); 
+
 
                     tipSVG.append("text")
-                        .text(SATdict[d.properties.ZIP])
+                        .text("SAT Score: " + SATdict[d.properties.ZIP])
                         .attr("x", 5)
-                        .attr("y", 30)
+                        .attr("y", 19)
                         .transition()
                         .duration(1000)
-                        .attr("x", 6 + SATbarwidth(SATdict[d.properties.ZIP]))
+                        .attr("x", 3)
+
+                // For Rent Bar:  
+                    tiprent.append("rect")
+                        .attr("fill", "red")
+                        .attr("y", 20)
+                        .attr("width", 0)
+                        .attr("height", 20) 
+                        .transition() 
+                        .duration(900) 
+                        .attr("width", function() {
+                           return barwidth(rentDict[d.properties.ZIP]);
+                        }); 
+                    tipSVG.append("text")
+                        .text("Rent Price: " + rentDict[d.properties.ZIP])
+                        .attr("x", 5)
+                        .attr("y", 40)
+                        .transition()
+                        .duration(1000)
+                        .attr("x", 3)
+
+
                 })
                 .on('mouseout', tool_tip.hide)
 
-                .on("click", function(d){newHeatMap.dispatch.call("selected", {}, SATdict[d.properties.ZIP]);}
-                   );
-                
-
-            });
+                //.on("click", function(d){newHeatMap.dispatch.call("selected", {}, SATdict[d.properties.ZIP]);});
+        
+                });
             });
         },
 
@@ -152,19 +177,10 @@ var heatMapVis = function(){
 }
 
 //determines whether the SATScore is a valid number for the bar length
-function SATbarwidth(SATscore) {
-    if (SATscore === undefined || isNaN(SATscore) ) {
-        return 2;
+function barwidth(value) {
+    if (value === undefined || isNaN(value) ) {
+        return 0;
     }      
-    return SATscore *.1;
+    return value *.1;
 }
 
-// given value, create the text for tooltips
-function tipsText(value) {
-
-}
-
-
-
-// if SAT is undefined, return empty bar with width 0
-// If SAT is null, return empty bar with width 0.

--- a/map/d3-tooltips.js
+++ b/map/d3-tooltips.js
@@ -1,0 +1,320 @@
+// d3.tip
+// Copyright (c) 2013 Justin Palmer
+// ES6 / D3 v4 Adaption Copyright (c) 2016 Constantin Gavrilete
+// Removal of ES6 for D3 v4 Adaption Copyright (c) 2016 David Gotz
+//
+// Tooltips for d3.js SVG visualizations
+
+d3.functor = function functor(v) {
+  return typeof v === "function" ? v : function() {
+    return v;
+  };
+};
+
+d3.tip = function() {
+
+  var direction = d3_tip_direction,
+      offset    = d3_tip_offset,
+      html      = d3_tip_html,
+      node      = initNode(),
+      svg       = null,
+      point     = null,
+      target    = null
+
+  function tip(vis) {
+    svg = getSVGNode(vis)
+    point = svg.createSVGPoint()
+    document.body.appendChild(node)
+  }
+
+  // Public - show the tooltip on the screen
+  //
+  // Returns a tip
+  tip.show = function() {
+    var args = Array.prototype.slice.call(arguments)
+    if(args[args.length - 1] instanceof SVGElement) target = args.pop()
+
+    var content = html.apply(this, args),
+        poffset = offset.apply(this, args),
+        dir     = direction.apply(this, args),
+        nodel   = getNodeEl(),
+        i       = directions.length,
+        coords,
+        scrollTop  = document.documentElement.scrollTop || document.body.scrollTop,
+        scrollLeft = document.documentElement.scrollLeft || document.body.scrollLeft
+
+    nodel.html(content)
+      .style('position', 'absolute')
+      .style('opacity', 1)
+      .style('pointer-events', 'all')
+
+    while(i--) nodel.classed(directions[i], false)
+    coords = direction_callbacks[dir].apply(this)
+    nodel.classed(dir, true)
+      .style('top', (coords.top +  poffset[0]) + scrollTop + 'px')
+      .style('left', (coords.left + poffset[1]) + scrollLeft + 'px')
+
+    return tip
+  }
+
+  // Public - hide the tooltip
+  //
+  // Returns a tip
+  tip.hide = function() {
+    var nodel = getNodeEl()
+    nodel
+      .style('opacity', 0)
+      .style('pointer-events', 'none')
+    return tip
+  }
+
+  // Public: Proxy attr calls to the d3 tip container.  Sets or gets attribute value.
+  //
+  // n - name of the attribute
+  // v - value of the attribute
+  //
+  // Returns tip or attribute value
+  tip.attr = function(n, v) {
+    if (arguments.length < 2 && typeof n === 'string') {
+      return getNodeEl().attr(n)
+    } else {
+      var args =  Array.prototype.slice.call(arguments)
+      d3.selection.prototype.attr.apply(getNodeEl(), args)
+    }
+
+    return tip
+  }
+
+  // Public: Proxy style calls to the d3 tip container.  Sets or gets a style value.
+  //
+  // n - name of the property
+  // v - value of the property
+  //
+  // Returns tip or style property value
+  tip.style = function(n, v) {
+    // debugger;
+    if (arguments.length < 2 && typeof n === 'string') {
+      return getNodeEl().style(n)
+    } else {
+      var args = Array.prototype.slice.call(arguments);
+      if (args.length === 1) {
+        var styles = args[0];
+        Object.keys(styles).forEach(function(key) {
+          return d3.selection.prototype.style.apply(getNodeEl(), [key, styles[key]]);
+        });
+      }
+    }
+
+    return tip
+  }
+
+  // Public: Set or get the direction of the tooltip
+  //
+  // v - One of n(north), s(south), e(east), or w(west), nw(northwest),
+  //     sw(southwest), ne(northeast) or se(southeast)
+  //
+  // Returns tip or direction
+  tip.direction = function(v) {
+    if (!arguments.length) return direction
+    direction = v == null ? v : d3.functor(v)
+
+    return tip
+  }
+
+  // Public: Sets or gets the offset of the tip
+  //
+  // v - Array of [x, y] offset
+  //
+  // Returns offset or
+  tip.offset = function(v) {
+    if (!arguments.length) return offset
+    offset = v == null ? v : d3.functor(v)
+
+    return tip
+  }
+
+  // Public: sets or gets the html value of the tooltip
+  //
+  // v - String value of the tip
+  //
+  // Returns html value or tip
+  tip.html = function(v) {
+    if (!arguments.length) return html
+    html = v == null ? v : d3.functor(v)
+
+    return tip
+  }
+
+  // Public: destroys the tooltip and removes it from the DOM
+  //
+  // Returns a tip
+  tip.destroy = function() {
+    if(node) {
+      getNodeEl().remove();
+      node = null;
+    }
+    return tip;
+  }
+
+  function d3_tip_direction() { return 'n' }
+  function d3_tip_offset() { return [0, 0] }
+  function d3_tip_html() { return ' ' }
+
+  var direction_callbacks = {
+    n:  direction_n,
+    s:  direction_s,
+    e:  direction_e,
+    w:  direction_w,
+    nw: direction_nw,
+    ne: direction_ne,
+    sw: direction_sw,
+    se: direction_se
+  };
+
+  var directions = Object.keys(direction_callbacks);
+
+  function direction_n() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.n.y - node.offsetHeight,
+      left: bbox.n.x - node.offsetWidth / 2
+    }
+  }
+
+  function direction_s() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.s.y,
+      left: bbox.s.x - node.offsetWidth / 2
+    }
+  }
+
+  function direction_e() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.e.y - node.offsetHeight / 2,
+      left: bbox.e.x
+    }
+  }
+
+  function direction_w() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.w.y - node.offsetHeight / 2,
+      left: bbox.w.x - node.offsetWidth
+    }
+  }
+
+  function direction_nw() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.nw.y - node.offsetHeight,
+      left: bbox.nw.x - node.offsetWidth
+    }
+  }
+
+  function direction_ne() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.ne.y - node.offsetHeight,
+      left: bbox.ne.x
+    }
+  }
+
+  function direction_sw() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.sw.y,
+      left: bbox.sw.x - node.offsetWidth
+    }
+  }
+
+  function direction_se() {
+    var bbox = getScreenBBox()
+    return {
+      top:  bbox.se.y,
+      left: bbox.e.x
+    }
+  }
+
+  function initNode() {
+    var node = d3.select(document.createElement('div'))
+    node
+      .style('position', 'absolute')
+      .style('top', 0)
+      .style('opacity', 0)
+      .style('pointer-events', 'none')
+      .style('box-sizing', 'border-box')
+
+    return node.node()
+  }
+
+  function getSVGNode(el) {
+    el = el.node()
+    if(el.tagName.toLowerCase() === 'svg')
+      return el
+
+    return el.ownerSVGElement
+  }
+
+  function getNodeEl() {
+    if(node === null) {
+      node = initNode();
+      // re-add node to DOM
+      document.body.appendChild(node);
+    };
+    return d3.select(node);
+  }
+
+  // Private - gets the screen coordinates of a shape
+  //
+  // Given a shape on the screen, will return an SVGPoint for the directions
+  // n(north), s(south), e(east), w(west), ne(northeast), se(southeast), nw(northwest),
+  // sw(southwest).
+  //
+  //    +-+-+
+  //    |   |
+  //    +   +
+  //    |   |
+  //    +-+-+
+  //
+  // Returns an Object {n, s, e, w, nw, sw, ne, se}
+  function getScreenBBox() {
+    var targetel   = target || d3.event.target;
+
+    while ('undefined' === typeof targetel.getScreenCTM && 'undefined' === targetel.parentNode) {
+        targetel = targetel.parentNode;
+    }
+
+    var bbox       = {},
+        matrix     = targetel.getScreenCTM(),
+        tbbox      = targetel.getBBox(),
+        width      = tbbox.width,
+        height     = tbbox.height,
+        x          = tbbox.x,
+        y          = tbbox.y
+
+    point.x = x
+    point.y = y
+    bbox.nw = point.matrixTransform(matrix)
+    point.x += width
+    bbox.ne = point.matrixTransform(matrix)
+    point.y += height
+    bbox.se = point.matrixTransform(matrix)
+    point.x -= width
+    bbox.sw = point.matrixTransform(matrix)
+    point.y -= height / 2
+    bbox.w  = point.matrixTransform(matrix)
+    point.x += width
+    bbox.e = point.matrixTransform(matrix)
+    point.x -= width / 2
+    point.y -= height / 2
+    bbox.n = point.matrixTransform(matrix)
+    point.y += height
+    bbox.s = point.matrixTransform(matrix)
+
+    return bbox
+  }
+
+  return tip
+};

--- a/map/map2.html
+++ b/map/map2.html
@@ -5,10 +5,21 @@
   stroke: steelblue;
   /* fill: #FFF; */
 }
+/*
+tooltip styling*/
+.d3-tip {
+  line-height: 1;
+  padding: 6px;
+  background: rgba(188, 224, 224, 0.74);
+  border-radius: 4px solid black;
+  font-size: 12px;
+}
 </style>
 
 <script src="https://d3js.org/d3.v4.min.js"></script>
 <script src="chicagoHeatMap.js"></script>
+<!-- script needed for making tooltips: -->
+<script src="d3-tooltips.js"></script> 
 <!-- <script src="Avg-SAT-by-Zip-Chi.csv.js"></script> -->
 <body>
   <svg id="chart" width="900" height="450"></svg>
@@ -26,6 +37,7 @@ var satSvg = d3.select("#SAT")
 
     HM.dispatch.on("selected",
                         function(d){
+                          console.log(d);
                           console.log(`AVG sat is: ${d}`);
                         });
 

--- a/tooltips/tooltip.html
+++ b/tooltips/tooltip.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<head>  
+
+  <script src="https://d3js.org/d3.v4.js"></script>
+<!--   <script src="tooltip.js"></script> -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.7.1/d3-tip.min.js"></script>
+</head>
+
+
+
+<style>
+.d3-tip {
+  line-height: 1;
+  padding: 6px;
+  background: wheat;
+  border-radius: 4px solid black;
+  font-size: 12px;
+}
+
+p {
+  font-family: Helvetica;
+}
+</style>
+
+<body>
+<p>Hover over the circles:</p>
+</body>
+
+<script>
+    var svg = d3.select("body")
+      .append("svg")
+      .attr("width", 300)
+      .attr("height", 300);
+
+    var tool_tip = d3.tip()
+      .attr("class", "d3-tip")
+      .offset([20, 120])
+      .html("<p>This is a SVG inside a tooltip:</p><div id='tipDiv'></div>");
+
+    svg.call(tool_tip);
+
+    var data = [14, 27, 19, 6, 17];
+
+    var circles = svg.selectAll("foo")
+      .data(data)
+      .enter()
+      .append("circle");
+
+    circles.attr("cx", 50)
+      .attr("cy", function(d, i) {
+        return 20 + 50 * i
+      })
+      .attr("r", function(d) {
+        return d
+      })
+      .attr("fill", "teal")
+
+
+      .on('mouseover', function(d) {
+            
+            tool_tip.show();
+            var tipSVG = d3.select("#tipDiv")
+              .append("svg")
+              .attr("width", 200)
+              .attr("height", 100);
+
+            tipSVG.append("rect")
+              .attr("fill", "steelblue")
+              .attr("y", 10) //y position of the bar
+              .attr("width", 0) //position of how far the bar starts at
+              .attr("height", 20) //the thickness of the bar
+              .transition() //facilitates the transition from empty canvas to bar
+              .duration(1000) //how long it takes for the bar to move
+              .attr("width", d * 6); //length of the bar
+
+            tipSVG.append("text")
+              .text(d)
+              .attr("x", 10)
+              .attr("y", 30)
+              .transition()
+              .duration(1000)
+              .attr("x", 6 + d * 6) //the location of the text is at the end of the bar
+      })
+      .on('mouseout', tool_tip.hide);
+</script>
+</html>
+

--- a/tooltips/tooltip.js
+++ b/tooltips/tooltip.js
@@ -1,0 +1,52 @@
+var svg = d3.select("body")
+  .append("svg")
+  .attr("width", 300)
+  .attr("height", 300);
+
+var tool_tip = d3.tip()
+  .attr("class", "d3-tip")
+  .offset([20, 120])
+  .html("<p>This is a SVG inside a tooltip:</p><div id='tipDiv'></div>");
+
+svg.call(tool_tip);
+
+var data = [14, 27, 19, 6, 17];
+
+var circles = svg.selectAll("foo")
+  .data(data)
+  .enter()
+  .append("circle");
+
+circles.attr("cx", 50)
+  .attr("cy", function(d, i) {
+    return 20 + 50 * i
+  })
+  .attr("r", function(d) {
+    return d
+  })
+  .attr("fill", "teal")
+  .on('mouseover', function(d) {
+    tool_tip.show();
+    var tipSVG = d3.select("#tipDiv")
+      .append("svg")
+      .attr("width", 200)
+      .attr("height", 50);
+
+    tipSVG.append("rect")
+      .attr("fill", "steelblue")
+      .attr("y", 10) //y position of the bar
+      .attr("width", 300)
+      .attr("height", 30)
+      .transition()
+      .duration(1000)
+      .attr("width", d * 6);
+
+    tipSVG.append("text")
+      .text(d)
+      .attr("x", 10)
+      .attr("y", 30)
+      .transition()
+      .duration(1000)
+      .attr("x", 6 + d * 6)
+  })
+  .on('mouseout', tool_tip.hide);


### PR DESCRIPTION
I added the tooltip functionality when neighborhoods are hoovered over. The main changes I made are as follows:

- For the built-in tooltip functionality to work, I had to import a d3-tooltips.js. 
- Almost all of the code for  tool-tips can be found within the .on(...) mouseover method.
- Added a variable to get the zipcode for each neighborhood
- Tool tips styling added in html file
